### PR TITLE
image attachment support

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,4 +6,5 @@ Authors
 Contributors
 ------------
 
+- Arno Hautala <arno@alum.wpiedu>: image attachment support
 - Your Name <email or twitter handle>: short description of your contribution, if you want

--- a/src/pushover_complete/pushover_api.py
+++ b/src/pushover_complete/pushover_api.py
@@ -112,7 +112,7 @@ class PushoverAPI(object):
         :type title: str
         :type url: str
         :type url_title: str
-        :type image_path: str
+        :type image_path: str or pathlib.Path
         :type priority: int
         :type retry: int
         :type expire: int
@@ -171,7 +171,7 @@ class PushoverAPI(object):
         :type title: str
         :type url: str
         :type url_title: str
-        :type image_path: str
+        :type image_path: str or pathlib.Path
         :type priority: int
         :type retry: int
         :type expire: int

--- a/src/pushover_complete/pushover_api.py
+++ b/src/pushover_complete/pushover_api.py
@@ -143,7 +143,7 @@ class PushoverAPI(object):
         
         if image_path is not None and os.path.isfile(image_path):
             with open(image_path, 'rb') as f:
-                file = {'attachment': (image_path, f)}
+                file = {'attachment': f}
                 return self._generic_post('messages.json', payload=payload, session=session, files=file)
         return self._generic_post('messages.json', payload=payload, session=session)
 

--- a/src/pushover_complete/pushover_api.py
+++ b/src/pushover_complete/pushover_api.py
@@ -141,11 +141,11 @@ class PushoverAPI(object):
             'html': html
         }
         
-        file = {}
         if image_path is not None and os.path.isfile(image_path):
-            file = {'attachment': (image_path, open(image_path, 'rb'))}
-
-        return self._generic_post('messages.json', payload=payload, session=session, files=file)
+            with open(image_path, 'rb') as f:
+                file = {'attachment': (image_path, f)}
+                return self._generic_post('messages.json', payload=payload, session=session, files=file)
+        return self._generic_post('messages.json', payload=payload, session=session)
 
     def send_message(self, user, message, device=None, title=None, url=None, url_title=None, image_path=None,
                      priority=None, retry=None, expire=None, callback_url=None, timestamp=None, sound=None, html=False):

--- a/src/pushover_complete/pushover_api.py
+++ b/src/pushover_complete/pushover_api.py
@@ -146,7 +146,7 @@ class PushoverAPI(object):
             if isinstance(image, file) or isinstance(image, io.BytesIO):
                     attachment = {'attachment': image}
                     return self._generic_post('messages.json', payload=payload, session=session, files=attachment)
-            if isinstance(image, str) and os.path.isfile(image):
+            if isinstance(image, six.string_types) and os.path.isfile(image):
                 with open(image, 'rb') as f:
                     attachment = {'attachment': f}
                     return self._generic_post('messages.json', payload=payload, session=session, files=attachment)

--- a/src/pushover_complete/pushover_api.py
+++ b/src/pushover_complete/pushover_api.py
@@ -57,12 +57,12 @@ class PushoverAPI(object):
         :param endpoint: The endpoint of the API to hit. Will be joined with "https://api.pushover.net/1/". Example value: "groups/{}.json"
         :param url_parameter: A parameter to replace in the endpoint string provided. Example value: "g123456". Combined with the above example value, would result in a final URL of "https://api.pushover.net/1/groups/g123456.json"
         :param payload: A dict of parameters to be appended to the URL, e.g. :code:`{'test-param': False}` would result in the URL having :code:`?test-param=false` appended. Do not include the application token in this dict, as it is added by the function.
-        :param files: A dict of file attachment parameters to be attached to the message
+        :param files: (optional) A dict of ``'attachment': value`` for attachment to the message. ``value`` may be a file-like object, or a tuple of at least ``('filename', file-like[, 'content_type'[, custom_headers_dict]])``. The optional 'content_type' string describes the file type and custom_headers_dict is a dict-like-object with additional headers describing the file
         :param session: A :class:`requests.Session` object to be used to send HTTP requests.
         :type endpoint: str
         :type url_parameter: str
         :type payload: dict
-        :type files: dict
+        :type files: dict{str,file-like} or dict{str,tuple(str,file-like[, str[, dict]])}
         :type session: requests.Session
 
         :returns: Response body interpreted as JSON

--- a/src/pushover_complete/pushover_api.py
+++ b/src/pushover_complete/pushover_api.py
@@ -1,10 +1,10 @@
+import os
 try:
     from urllib.parse import urljoin
 except ImportError:
     from urlparse import urljoin
 
 import requests
-import os
 
 from .error import BadAPIRequestError
 


### PR DESCRIPTION
Pushover today added support for image attachments.
This PR adds support for specifying the path to an image when calling send_message.

`send_message(…, image_path="/path/to/the/image")`