### PR TITLE
Update license field to use proper SPDX identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ maintainers = [
     { name = "Scott Colby", email = "scott@scolby.com" }
 ]
 description = "A Python package for interacting with *all* aspects of the Pushover API."
+license = "MIT"
 readme = "README.rst"
 keywords = ["pushover", "message", "push"]
 classifiers = [


### PR DESCRIPTION
This changes the license field to be a valid [SPDX identifier](https://spdx.org/licenses) aligning with [PEP 639](https://peps.python.org/pep-0639/#project-source-metadata). This populates the `license_expression` field in the PyPI API which is used by downstream tools including deps.dev

This PR was generated by Claude after reviewing the license and manifest files in repository, but reviewed by me before submitting.