### PR TITLE
Add cancel_by_tag support

### DIFF
--- a/src/pushover_complete/pushover_api.py
+++ b/src/pushover_complete/pushover_api.py
@@ -364,6 +364,24 @@ class PushoverAPI:
         """
         return self._generic_post("receipts/{}/cancel.json", receipt)
 
+    def cancel_by_tag(self, tag):
+        """
+        Cancel all active emergency-priority messages with the given tag.
+
+        If your application is not capable of storing receipt identifiers, you can instead
+        send a ``tags`` parameter when creating an emergency-priority message and use this
+        method to cancel all matching receipts at once.
+
+        .. seealso:: :meth:`PushoverAPI.cancel_receipt`
+
+        :param tag: The tag for which all active emergency-priority receipts will be cancelled
+        :type tag: str
+
+        :returns: Response body interpreted as JSON
+        :rtype: dict
+        """
+        return self._generic_post("receipts/cancel_by_tag/{}.json", tag)
+
     def _migrate_to_subscription(self, user, subscription_code, device=None, sound=None, session=None):
         """
         Migrates a user key to a subscription key.

--- a/tests/PushoverAPI/test_PushoverAPI.py
+++ b/tests/PushoverAPI/test_PushoverAPI.py
@@ -30,6 +30,7 @@ from tests.constants import (
     TEST_REQUEST_ID,
     TEST_SUBSCRIBED_USER_KEY,
     TEST_SUBSCRIPTION_CODE,
+    TEST_TAG,
     TEST_TITLE,
     TEST_URL,
     TEST_URL_TITLE,
@@ -52,6 +53,7 @@ from tests.responses_callbacks import (
     messages_callback,
     receipt_callback,
     receipt_cancel_callback,
+    receipt_cancel_by_tag_callback,
     sounds_callback,
     subscription_migrate_callback,
     validate_callback,
@@ -387,6 +389,35 @@ def test_PushoverAPI_raises_error_on_bad_receipt_cancel(PushoverAPI):
     )
     with pytest.raises(BadAPIRequestError):
         PushoverAPI.cancel_receipt("r" + TEST_BAD_GENERAL_ID)
+
+
+@responses.activate
+def test_PushoverAPI_cancels_by_tag(PushoverAPI):
+    """Test cancelling all active emergency-priority receipts by tag."""
+    url_re = re.compile(r"https://api\.pushover\.net/1/receipts/cancel_by_tag/[a-zA-Z0-9_-]+\.json")
+    responses.add_callback(
+        responses.POST,
+        url_re,
+        callback=receipt_cancel_by_tag_callback,
+        content_type="application/json",
+    )
+    resp = PushoverAPI.cancel_by_tag(TEST_TAG)
+
+    assert resp == {"status": 1, "request": TEST_REQUEST_ID}
+
+
+@responses.activate
+def test_PushoverAPI_raises_error_on_bad_tag_cancel(PushoverAPI):
+    """Test the cancelling with a tag that has no active receipts."""
+    url_re = re.compile(r"https://api\.pushover\.net/1/receipts/cancel_by_tag/[a-zA-Z0-9_-]+\.json")
+    responses.add_callback(
+        responses.POST,
+        url_re,
+        callback=receipt_cancel_by_tag_callback,
+        content_type="application/json",
+    )
+    with pytest.raises(BadAPIRequestError):
+        PushoverAPI.cancel_by_tag(TEST_BAD_GENERAL_ID)
 
 
 @responses.activate

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -11,6 +11,7 @@ TEST_TITLE = "Backup finished - SQL1"
 TEST_MESSAGE = 'Backup of database "example" finished in 16 minutes.'
 TEST_REQUEST_ID = "e460545a8b333d0da2f3602aff3133d6"
 TEST_RECEIPT_ID = "rLqVuqTRh62UzxtmqiaLzQmVcPgiCy"
+TEST_TAG = "server-down"
 TEST_URL = "twitter://direct_message?screen_name=someuser"
 TEST_URL_TITLE = "Reply to @someuser"
 TEST_SUBSCRIPTION_CODE = "Forum-f504h08fhlasdfj"

--- a/tests/responses_callbacks.py
+++ b/tests/responses_callbacks.py
@@ -18,6 +18,7 @@ from tests.constants import (
     TEST_REQUEST_ID,
     TEST_SUBSCRIBED_USER_KEY,
     TEST_SUBSCRIPTION_CODE,
+    TEST_TAG,
     TEST_TOKEN,
     TEST_USER,
     TEST_USER_EMAIL,
@@ -235,6 +236,45 @@ def receipt_cancel_callback(request):
         resp_body["receipt"] = "not found"
         resp_body["status"] = 0
         resp_body["errors"] = ["receipt not found; may be invalid or expired"]
+    else:
+        resp_body["status"] = 1
+
+    return 200 if resp_body["status"] == 1 else 400, headers, json.dumps(resp_body)
+
+
+def receipt_cancel_by_tag_callback(request):
+    r"""
+    Mock the /receipts/cancel_by_tag/{tag}.json endpoint.
+
+    Best used like so::
+
+        url_re = re.compile(r'https://api\.pushover\.net/1/receipts/cancel_by_tag/[a-zA-Z0-9_-]+\.json')
+        responses.add_callback(
+            responses.POST,
+            url_re,
+            callback=receipt_cancel_by_tag_callback,
+            content_type='application/json'
+        )
+
+    in order to capture all calls to the endpoint.
+    """
+    resp_body = {"request": TEST_REQUEST_ID}
+    headers = {"X-Request-Id": TEST_REQUEST_ID}
+
+    req_body = getattr(request, "body", None)
+    qs = parse_qs(req_body)
+    qs = {k: v[0] for k, v in qs.items()}
+
+    if qs.get("token") != TEST_TOKEN:
+        resp_body["token"] = "invalid"  # noqa: S105 -- not a real secret
+        resp_body["status"] = 0
+        resp_body["errors"] = ["application token is invalid"]
+    elif (
+        request.path_url.split("/")[-1].split(".")[0] != TEST_TAG
+    ):  # get the tag from a url of the form /1/receipts/cancel_by_tag/{tag}.json
+        resp_body["tag"] = "not found"
+        resp_body["status"] = 0
+        resp_body["errors"] = ["tag not found or no active receipts for this tag"]
     else:
         resp_body["status"] = 1
 


### PR DESCRIPTION
# Add `cancel_by_tag` support

## What

Adds a new `cancel_by_tag(tag)` method to `PushoverAPI`, implementing the
[[cancel_by_tag receipts endpoint](https://pushover.net/api/receipts#cancel-by-tag)](https://pushover.net/api/receipts#cancel-by-tag)
of the Pushover API.

## Why

The Pushover API allows attaching arbitrary tags to emergency-priority messages
via the `tags` parameter. These tags can be used to cancel all matching receipts
at once - without needing to store individual receipt IDs. This is useful for
applications like monitoring systems that may send many related emergency
notifications (e.g. per-server alerts) and want to cancel them all at once when
an issue is resolved.

## Usage

```python
p = PushoverAPI("your_app_token")

# Send emergency message with a tag (tags parameter is passed through as-is)
p.send_message(
    "user_token",
    "Server mail01 is down",
    priority=2,
    retry=60,
    expire=3600,
    tags="mail01,rack-a,chicago",
)

# Later: cancel all receipts tagged "chicago"
p.cancel_by_tag("chicago")
```

## Changes

### `src/pushover_complete/pushover_api.py`

Added `cancel_by_tag(tag)` method after `cancel_receipt()`. It follows the
exact same pattern as the existing `cancel_receipt()` method - a single call
to `_generic_post` with the tag as the URL parameter:

```
POST https://api.pushover.net/1/receipts/cancel_by_tag/{tag}.json
```

### `tests/PushoverAPI/test_PushoverAPI.py`

Added two new tests after the existing receipt cancel tests:

- `test_PushoverAPI_cancels_by_tag` - verifies a successful cancel call
- `test_PushoverAPI_raises_error_on_bad_tag_cancel` - verifies that a
  `BadAPIRequestError` is raised when the tag has no active receipts

The new tests import `receipt_cancel_by_tag_callback` from `responses_callbacks`
and `TEST_TAG` from `constants`, following the exact same structure as the
existing receipt cancel tests.

### `tests/responses_callbacks.py`

Added `receipt_cancel_by_tag_callback` to mock the
`/receipts/cancel_by_tag/{tag}.json` endpoint. It validates the app token and
checks that the tag in the URL matches `TEST_TAG`, returning a 400 error
otherwise. Also added `TEST_TAG` to the imports from `tests.constants`.

### `tests/constants.py`

Added one new constant:

```python
TEST_TAG = "server-down"
```